### PR TITLE
Add detailed EuroSAT dataset and DenseNet-121 model info

### DIFF
--- a/data/dataset-info.md
+++ b/data/dataset-info.md
@@ -1,0 +1,49 @@
+# EuroSAT Dataset
+
+## Dataset Overview
+**EuroSAT** is a land use and land cover classification dataset based on Sentinel-2 satellite images covering 13 spectral bands and consisting of 10 classes with a total of 27,000 labeled and geo-referenced images.
+
+## Dataset Details
+- **Name**: EuroSAT
+- **Source**: [HuggingFace Datasets](https://huggingface.co/datasets/blanchon/EuroSAT_RGB)
+- **Total Images**: 27,000
+- **Image Format**: RGB (3 channels)
+- **Image Resolution**: 64x64 pixels
+- **File Format**: JPEG
+
+## Classes (10 total)
+1. **AnnualCrop** - Annually harvested crops
+2. **Forest** - Forest areas
+3. **HerbaceousVegetation** - Herbaceous vegetation
+4. **Highway** - Highway infrastructure
+5. **Industrial** - Industrial areas
+6. **Pasture** - Pasture lands
+7. **PermanentCrop** - Permanently cultivated crops
+8. **Residential** - Residential areas
+9. **River** - River bodies
+10. **SeaLake** - Sea and lake water bodies
+
+## Data Split
+- **Training**: 80% (21,600 images)
+- **Testing**: 20% (5,400 images)
+- **Split Method**: Stratified random split to maintain class distribution
+
+## Storage Information
+- **Location**: No local storage - downloaded at runtime
+- **Download Method**: Automatic download via HuggingFace datasets library
+- **Runtime Storage**: Temporary storage in Colab environment during execution
+- **Persistent Storage**: Google Drive for model checkpoints and results
+
+## Usage
+The dataset is automatically downloaded and processed during notebook execution. No manual download required.
+
+## Citation
+If using this dataset, please cite:
+```
+Helber, P., Bischke, B., Dengel, A., & Borth, D. (2019). 
+EuroSAT: A novel dataset and deep learning benchmark for land use and land cover classification. 
+IEEE Journal of Selected Topics in Applied Earth Observations and Remote Sensing, 12(7), 2217-2226.
+```
+
+## License
+The dataset is available under the MIT License.

--- a/data/dataset121-info.txt.txt
+++ b/data/dataset121-info.txt.txt
@@ -1,6 +1,0 @@
-Dataset: EuroSAT
-Source: https://huggingface.co/datasets/blanchon/EuroSAT_RGB
-Total Images: 27,000
-Classes: 10 (AnnualCrop, Forest, HerbaceousVegetation, Highway, Industrial, Pasture, PermanentCrop, Residential, River, SeaLake)
-Split: 80% Train / 20% Test
-Location: No local stored location downloaded at runtime

--- a/models/densenet121-model-info.md
+++ b/models/densenet121-model-info.md
@@ -1,0 +1,38 @@
+# DenseNet-121 Model
+
+## Model Specifications
+
+- **Architecture:** DenseNet-121
+- **Pretrained on:** ImageNet
+- **Total Parameters:** 7.6M
+- **Dataset Split:** 80% Training / 20% Testing
+
+## Performance
+
+- **Accuracy:** TBD% (EuroSAT dataset)
+- **Training Status:** In Progress/Completed
+- **Training Epochs:** 35
+
+## Model File
+
+- **Saved Location:** Google Drive (too large for GitHub)
+- **Download Link:** [DenseNet-121 Weights](https://drive.google.com/file/d/1VsgdHVt8kFw2WLxvnSb14tXa3MkVO5HA/view?usp=sharing)
+- **File Size:** 88MB
+
+## Model Architecture Details
+
+- **Backbone:** DenseNet-121 with ImageNet pretraining
+- **Classifier Head:** Custom 3-layer classifier with dropout and batch normalization
+- **Input Size:** 224×224×3 (RGB images)
+- **Output Classes:** 10 (EuroSAT land use categories)
+
+## Training Configuration
+
+- **Optimizer:** AdamW with weight decay
+- **Learning Rate:** 0.0008 (optimized for DenseNet)
+- **Loss Function:** CrossEntropyLoss with label smoothing
+- **Data Augmentation:** Horizontal/vertical flips, rotation, color jitter
+
+## Usage
+
+This model is trained for satellite image classification on the EuroSAT dataset and can be used for land use and land cover classification tasks.


### PR DESCRIPTION
Added a comprehensive markdown file describing the EuroSAT dataset and its usage in data/dataset-info.md. Removed the old dataset121-info.txt.txt file. Introduced a new models/densenet121-model-info.md file with specifications, architecture, and training details for the DenseNet-121 model used for EuroSAT land use classification.